### PR TITLE
Removing double spaces and new lines from CSV

### DIFF
--- a/src/Component/CsvExport.php
+++ b/src/Component/CsvExport.php
@@ -154,7 +154,12 @@ class CsvExport extends Part
 
     protected function escapeString($str)
     {
-        return str_replace('"', '\'', strip_tags(html_entity_decode($str)));
+        $str = html_entity_decode($str);
+        $str = strip_tags($str);
+        $str = str_replace('"', '\'', $str);
+        $str = preg_replace('/\s+/', ' ', $str);
+        $str = trim($str);
+        return $str;
     }
 
     /**


### PR DESCRIPTION
Need do some string cleanup.
Remove >1 spaces and all new lines, trailing spaces.
To avoid incorrect display in Excel/Calc columns after html code stripping.

OO Calc: http://dsro.ru/gyazo/images/046186fb43d10e6092e05b7fbfab.png
MS Excel: http://dsro.ru/gyazo/images/c20a37008265555a18f7ccf55e99.png